### PR TITLE
Fixes #12 : use false result check at stmt->fetchObject() to handle username not found data ( auth failure )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.2.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#13](https://github.com/zendframework/zend-expressive-authentication/pull/13) fixes "Trying to get property of non-object" when no record found at PdoDatabase user repository.
+
 ## 0.2.0 - 2017-11-27
 
 ### Added

--- a/src/UserRepository/PdoDatabase.php
+++ b/src/UserRepository/PdoDatabase.php
@@ -49,12 +49,12 @@ class PdoDatabase implements UserRepositoryInterface
 
         $stmt = $this->pdo->prepare($sql);
         $stmt->bindParam(':username', $credential);
-
-        if (! $stmt->execute()) {
-            return null;
-        }
+        $stmt->execute();
 
         $result = $stmt->fetchObject();
+        if (! $result) {
+            return null;
+        }
 
         return password_verify($password, $result->{$this->config['field']['password']})
             ? $this->generateUser($credential, $this->getRolesFromUser($credential))

--- a/test/UserRepository/PdoDatabaseTest.php
+++ b/test/UserRepository/PdoDatabaseTest.php
@@ -51,6 +51,21 @@ class PdoDatabaseTest extends TestCase
         $this->assertNull($user);
     }
 
+    public function testAuthenticateInvalidUsername()
+    {
+        $pdo = new PDO('sqlite:'. __DIR__ . '/../TestAssets/pdo.sqlite');
+        $pdoDatabase = new PdoDatabase($pdo, [
+            'table' => 'user',
+            'field' => [
+                'username' => 'username',
+                'password' => 'password'
+            ]
+        ]);
+
+        $user = $pdoDatabase->authenticate('invaliduser', 'foo');
+        $this->assertNull($user);
+    }
+
     public function testAuthenticateWithRole()
     {
         $pdo = new PDO('sqlite:'. __DIR__ . '/../TestAssets/pdo_role.sqlite');

--- a/test/UserRepository/PdoDatabaseTest.php
+++ b/test/UserRepository/PdoDatabaseTest.php
@@ -36,7 +36,7 @@ class PdoDatabaseTest extends TestCase
         $this->assertEquals('test', $user->getUsername());
     }
 
-    public function testAuthenticateInvalidUser()
+    public function testAuthenticateInvalidUserPassword()
     {
         $pdo = new PDO('sqlite:'. __DIR__ . '/../TestAssets/pdo.sqlite');
         $pdoDatabase = new PdoDatabase($pdo, [
@@ -62,7 +62,7 @@ class PdoDatabaseTest extends TestCase
             ]
         ]);
 
-        $user = $pdoDatabase->authenticate('invaliduser', 'password');
+        $user = $pdoDatabase->authenticate('invalidusername', 'password');
         $this->assertNull($user);
     }
 

--- a/test/UserRepository/PdoDatabaseTest.php
+++ b/test/UserRepository/PdoDatabaseTest.php
@@ -62,7 +62,7 @@ class PdoDatabaseTest extends TestCase
             ]
         ]);
 
-        $user = $pdoDatabase->authenticate('invaliduser', 'foo');
+        $user = $pdoDatabase->authenticate('invaliduser', 'password');
         $this->assertNull($user);
     }
 


### PR DESCRIPTION
This fixes a bug that occurs when the user provides an incorrect username (username not found in DB); currently, it generates the error "Trying to get property of non-object".

The error occurs due to incorrectly checking for a false result from a `$stmt->execute()` call; this should happen against a later `$stmt->fetchObject()` call instead.
