### PR TITLE
Allow usage of ResponseInterface services that return a factory

### DIFF
--- a/src/ResponsePrototypeTrait.php
+++ b/src/ResponsePrototypeTrait.php
@@ -29,8 +29,12 @@ trait ResponsePrototypeTrait
                 ResponseInterface::class
             ));
         }
-        return $container->has(ResponseInterface::class)
+
+        $response = $container->has(ResponseInterface::class)
             ? $container->get(ResponseInterface::class)
             : new Response();
+
+        // Allow usage of callable factories to generate a response.
+        return is_callable($response) ? $response() : $response;
     }
 }


### PR DESCRIPTION
Expressive 2.2 returns a factory instead of an instance; this allows you to us that factory to generate the instance.