### PR TITLE
Use iterable for roles instead of array

### DIFF
--- a/src/UserInterface.php
+++ b/src/UserInterface.php
@@ -21,5 +21,5 @@ interface UserInterface
      *
      * @return string[]
      */
-    public function getUserRoles() : array;
+    public function getUserRoles() : iterable;
 }


### PR DESCRIPTION
To allow getUserRoles to return an object that is traversable.

See: https://github.com/zendframework/zend-expressive-authentication/issues/26