### PR TITLE
Fixes site name for MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ pages:
     - Reference:
       - 'Authentication adapter': v1/auth-adapter.md
       - 'User repository': v1/user-repository.md
-site_name: Authentication middleware
+site_name: zend-expressive-authentication
 site_description: 'Authentication middleware for Expressive and PSR-7 applications'
 repo_url: 'https://github.com/zendframework/zend-expressive-authentication'
 copyright: 'Copyright (c) 2018 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'


### PR DESCRIPTION
@xerkus found this bug and [reported it on Slack:](https://zendframework.slack.com/archives/CAP4J90LW/p1527251193000432)

https://github.com/zendframework/zend-expressive-authentication/blob/486cb20dc81df864ee4706e8d191fc87ad0af91b/mkdocs.yml#L9

This results in a wrong header and installation command in the documentation:

> ## Authentication middleware
> 
> `$ composer require zendframework/Authentication middleware`

https://docs.zendframework.com/zend-expressive-authentication/