### PR TITLE
Allow PSR-7 compliant request to be passed to UserRepositoryInterface

### DIFF
--- a/docs/book/v1/user-repository.md
+++ b/docs/book/v1/user-repository.md
@@ -23,13 +23,14 @@ interface UserRepositoryInterface
      *
      * @param string $credential can be also a token
      */
-    public function authenticate(string $credential, string $password = null) : ?UserInterface;
+    public function authenticate(string $credential, string $password = null, ServerRequestInterface $request = null) : ?UserInterface;
 }
 ```
 
 It contains only the `authenticate()` function, to authenticate the user's
 credential. If authenticated, the result will be a `UserInterface` instance;
 otherwise, a `null` value is returned.
+It also provides access to an optional PSR-7 compliant `$request` instance, should you need to persist request-related authentication information.
 
 ## Configure the user repository
 

--- a/src/UserRepository/Htpasswd.php
+++ b/src/UserRepository/Htpasswd.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Authentication\UserRepository;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Authentication\Exception;
 use Zend\Expressive\Authentication\UserInterface;
 use Zend\Expressive\Authentication\UserRepositoryInterface;
@@ -56,8 +57,11 @@ class Htpasswd implements UserRepositoryInterface
     /**
      * {@inheritDoc}
      */
-    public function authenticate(string $credential, string $password = null) : ?UserInterface
-    {
+    public function authenticate(
+        string $credential,
+        string $password = null,
+        ServerRequestInterface $request = null
+    ) : ?UserInterface {
         if (! $handle = fopen($this->filename, 'r')) {
             return null;
         }

--- a/src/UserRepository/PdoDatabase.php
+++ b/src/UserRepository/PdoDatabase.php
@@ -11,6 +11,7 @@ namespace Zend\Expressive\Authentication\UserRepository;
 
 use PDO;
 use PDOException;
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Authentication\Exception;
 use Zend\Expressive\Authentication\UserInterface;
 use Zend\Expressive\Authentication\UserRepositoryInterface;
@@ -58,8 +59,11 @@ class PdoDatabase implements UserRepositoryInterface
     /**
      * {@inheritDoc}
      */
-    public function authenticate(string $credential, string $password = null) : ?UserInterface
-    {
+    public function authenticate(
+        string $credential,
+        string $password = null,
+        ServerRequestInterface $request = null
+    ) : ?UserInterface {
         $sql = sprintf(
             "SELECT %s FROM %s WHERE %s = :identity",
             $this->config['field']['password'],

--- a/src/UserRepositoryInterface.php
+++ b/src/UserRepositoryInterface.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Authentication;
 
+use Psr\Http\Message\ServerRequestInterface;
+
 interface UserRepositoryInterface
 {
     /**
@@ -18,5 +20,9 @@ interface UserRepositoryInterface
      *
      * @param string $credential can be also a token
      */
-    public function authenticate(string $credential, string $password = null) : ?UserInterface;
+    public function authenticate(
+        string $credential,
+        string $password = null,
+        ServerRequestInterface $request = null
+    ) : ?UserInterface;
 }

--- a/test/UserRepository/HtpasswdTest.php
+++ b/test/UserRepository/HtpasswdTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Expressive\Authentication\UserRepository;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Authentication\UserInterface;
 use Zend\Expressive\Authentication\UserRepositoryInterface;
 use Zend\Expressive\Authentication\UserRepository\Htpasswd;
@@ -24,10 +25,16 @@ class HtpasswdTest extends TestCase
      */
     private $user;
 
+    /**
+     * @var ObjectProphecy|ServerRequestInterface
+     */
+    private $request;
+
     protected function setUp()
     {
         $this->user = $this->prophesize(UserInterface::class);
         $this->user->getIdentity()->willReturn(self::EXAMPLE_IDENTITY);
+        $this->request = $this->prophesize(ServerRequestInterface::class);
     }
     /**
      * @expectedException \Zend\Expressive\Authentication\Exception\InvalidConfigException
@@ -62,7 +69,7 @@ class HtpasswdTest extends TestCase
             }
         );
 
-        $user = $htpasswd->authenticate(self::EXAMPLE_IDENTITY, 'password');
+        $user = $htpasswd->authenticate(self::EXAMPLE_IDENTITY, 'password', $this->request->reveal());
         $this->assertInstanceOf(UserInterface::class, $user);
         $this->assertEquals(self::EXAMPLE_IDENTITY, $user->getIdentity());
     }

--- a/test/UserRepository/HtpasswdTest.php
+++ b/test/UserRepository/HtpasswdTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Expressive\Authentication\UserRepository;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Zend\Expressive\Authentication\UserInterface;
 use Zend\Expressive\Authentication\UserRepositoryInterface;
 use Zend\Expressive\Authentication\UserRepository\Htpasswd;
@@ -19,13 +20,18 @@ class HtpasswdTest extends TestCase
 {
     const EXAMPLE_IDENTITY = 'test';
 
+    /**
+     * @var ObjectProphecy|UserInterface
+     */
+    private $user;
+
     protected function setUp()
     {
         $this->user = $this->prophesize(UserInterface::class);
         $this->user->getIdentity()->willReturn(self::EXAMPLE_IDENTITY);
     }
     /**
-     * @expectedException Zend\Expressive\Authentication\Exception\InvalidConfigException
+     * @expectedException \Zend\Expressive\Authentication\Exception\InvalidConfigException
      */
     public function testConstructorWithNoFile()
     {
@@ -85,7 +91,7 @@ class HtpasswdTest extends TestCase
     }
 
     /**
-     * @expectedException Zend\Expressive\Authentication\Exception\RuntimeException
+     * @expectedException \Zend\Expressive\Authentication\Exception\RuntimeException
      */
     public function testAuthenticateWithInsecureHash()
     {

--- a/test/UserRepository/HtpasswdTest.php
+++ b/test/UserRepository/HtpasswdTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Authentication\UserRepository;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Zend\Expressive\Authentication\UserInterface;
 use Zend\Expressive\Authentication\UserRepositoryInterface;

--- a/test/UserRepository/PdoDatabaseTest.php
+++ b/test/UserRepository/PdoDatabaseTest.php
@@ -11,6 +11,8 @@ namespace ZendTest\Expressive\Authentication\UserRepository;
 
 use PDO;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Authentication\DefaultUser;
 use Zend\Expressive\Authentication\Exception\InvalidConfigException;
 use Zend\Expressive\Authentication\Exception\RuntimeException;
@@ -25,11 +27,17 @@ class PdoDatabaseTest extends TestCase
      */
     private $userFactory;
 
+    /**
+     * @var ObjectProphecy|ServerRequestInterface
+     */
+    private $request;
+
     protected function setUp()
     {
         $this->userFactory = function ($identity, $roles, $details) {
             return new DefaultUser($identity, $roles, $details);
         };
+        $this->request = $this->prophesize(ServerRequestInterface::class);
     }
 
     public function testConstructor()
@@ -62,7 +70,7 @@ class PdoDatabaseTest extends TestCase
             $this->userFactory
         );
 
-        $user = $pdoDatabase->authenticate('test', 'password');
+        $user = $pdoDatabase->authenticate('test', 'password', $this->request->reveal());
         $this->assertInstanceOf(UserInterface::class, $user);
         $this->assertEquals('test', $user->getIdentity());
     }

--- a/test/UserRepository/PdoDatabaseTest.php
+++ b/test/UserRepository/PdoDatabaseTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Expressive\Authentication\UserRepository;
 
 use PDO;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Zend\Expressive\Authentication\DefaultUser;
 use Zend\Expressive\Authentication\Exception\InvalidConfigException;
 use Zend\Expressive\Authentication\Exception\RuntimeException;

--- a/test/UserRepository/PdoDatabaseTest.php
+++ b/test/UserRepository/PdoDatabaseTest.php
@@ -21,6 +21,11 @@ use Zend\Expressive\Authentication\UserRepository\PdoDatabase;
 
 class PdoDatabaseTest extends TestCase
 {
+    /**
+     * @var callable
+     */
+    private $userFactory;
+
     protected function setUp()
     {
         $this->userFactory = function ($identity, $roles, $details) {


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:
- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
Upon authentication, you may need, for example, to persist end-user remote IP address or header user-agent. As `Zend\Expressive\Authentication\AuthenticationInterface` passes a `Psr\Http\Message\ServerRequestInterface` instance, this request can be passed to the adapter.
  - [x] How will users use the new feature?
Simply rely on the `Psr\Http\Message\ServerRequestInterface` instance in the `authenticate` method of the adapter to retrieve request attributes you need.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
