### PR TITLE
added realm to htpasswd configuration, added bcrypt hint

### DIFF
--- a/docs/book/v1/user-repository.md
+++ b/docs/book/v1/user-repository.md
@@ -52,11 +52,12 @@ for more information on config providers.
 ## htpasswd configuration
 
 When using the htpasswd user repository implementation, you need only configure
-the path to the `htpasswd` file:
+the path to the `htpasswd` file and a `realm`. The `htpasswd` file must use bcrypt hash algorithm:
 
 ```php
 return [
     'authentication' => [
+        'realm' => 'insert realm value',
         'htpasswd' => 'insert the path to htpasswd file',
     ],
 ];


### PR DESCRIPTION
The realm is required to prevent an InvalidConfigException in BasicAccessFactory from zendframework/zend-expressive-authentication-basic.

Since it's checked and RFC 2617 says "The realm attribute (case-insensitive) is required for all authentication schemes which issue a challenge.", it should be save to add it to the docs.

Also the .htpasswd file must use bcrypt hash algorithm, otherwise a RuntimeException is thrown.

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
