### PR TITLE
Handle the password field having a value of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#37](https://github.com/zendframework/zend-expressive-authentication/pull/37) handles null values when verifying password in `PdoDatabase`
 
 ## 1.0.0 - 2018-08-27
 

--- a/src/UserRepository/PdoDatabase.php
+++ b/src/UserRepository/PdoDatabase.php
@@ -82,7 +82,7 @@ class PdoDatabase implements UserRepositoryInterface
             return null;
         }
 
-        if (password_verify($password, $result->{$this->config['field']['password']})) {
+        if (password_verify($password ?? '', $result->{$this->config['field']['password']} ?? '')) {
             return ($this->userFactory)(
                 $credential,
                 $this->getUserRoles($credential),


### PR DESCRIPTION
If any of the arguments to `password_verify` is null it will throw a `TypeError`.
This uses the same fix as Htpasswd.
https://github.com/zendframework/zend-expressive-authentication/blob/358795c0348e8b25e9c25d74ab3604cdd87ef92e/src/UserRepository/Htpasswd.php#L76