### PR TITLE
A new IdentityInterface for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.0.1 - TBD
+## 1.0.2 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.0.1 - 2018-09-28
 
 ### Added
 

--- a/src/AuthenticationInterface.php
+++ b/src/AuthenticationInterface.php
@@ -15,10 +15,10 @@ use Psr\Http\Message\ResponseInterface;
 interface AuthenticationInterface
 {
     /**
-     * Authenticate the PSR-7 request and return a valid user
+     * Authenticate the PSR-7 request and return a valid identity
      * or null if not authenticated
      */
-    public function authenticate(ServerRequestInterface $request) : ?UserInterface;
+    public function authenticate(ServerRequestInterface $request) : ?IdentityInterface;
 
     /**
      * Generate the unauthorized response

--- a/src/AuthenticationMiddleware.php
+++ b/src/AuthenticationMiddleware.php
@@ -31,9 +31,12 @@ class AuthenticationMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
-        $user = $this->auth->authenticate($request);
-        if (null !== $user) {
-            return $handler->handle($request->withAttribute(UserInterface::class, $user));
+        $identity = $this->auth->authenticate($request);
+        if (null !== $identity) {
+            if ($identity instanceof UserInterface) {
+                return $handler->handle($request->withAttribute(UserInterface::class, $identity));
+            }
+            return $handler->handle($request->withAttribute(IdentityInterface::class, $identity));
         }
         return $this->auth->unauthorizedResponse($request);
     }

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -9,22 +9,10 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Authentication;
 
-interface UserInterface extends IdentityInterface
+interface IdentityInterface
 {
     /**
-     * Get all user roles
-     *
-     * @return Iterable
+     * Get the unique identity
      */
-    public function getRoles() : iterable;
-
-    /**
-     * Get a detail $name if present, $default otherwise
-     */
-    public function getDetail(string $name, $default = null);
-
-    /**
-     * Get all the details, if any
-     */
-    public function getDetails() : array;
+    public function getIdentity() : string;
 }


### PR DESCRIPTION
This PR is a work in progress to solve the issue about OAuth2 client authentication reported in https://github.com/zendframework/zend-expressive-authentication-oauth2/pull/55. The idea is to use a general `IdentityInterface` as follows:

```php
namespace Zend\Expressive\Authentication;

interface IdentityInterface
{
    /**
     * Get the unique identity
     */
    public function getIdentity() : string;
}
```
And a specific `UserInterface` that extends the `IdentityInterface`, as follows:

```php
namespace Zend\Expressive\Authentication;

interface UserInterface extends IdentityInterface
{
    /**
     * Get all user roles
     *
     * @return Iterable
     */
    public function getRoles() : iterable;

    /**
     * Get a detail $name if present, $default otherwise
     */
    public function getDetail(string $name, $default = null);

    /**
     * Get all the details, if any
     */
    public function getDetails() : array;
}
```

Regarding the `AuthenticationMiddleware`, this PR generates a `UserInterface` PSR-7 attribute if `authenticate($request)` returns an instance of `UserInterface`. Otherwise, it will returns a `IdentityInterface` attribute.

These changes *should* prevent BC breaks for existing implementations using `zend-expressive-authentication` and offers a new solution to `zend-expressive-authentication-oauth2` for implementing a `ClientInterface` (extending `IdentityInterface`).


