### PR TITLE
Throw exception when query does not work

### DIFF
--- a/src/UserRepository/PdoDatabase.php
+++ b/src/UserRepository/PdoDatabase.php
@@ -128,8 +128,8 @@ class PdoDatabase implements UserRepositoryInterface
         if (! $stmt->execute()) {
             throw new Exception\RuntimeException(sprintf(
                 "Error when running query from config sql_get_roles: "
-                .implode($stmt->errorInfo(),' '))
-            );
+                .implode($stmt->errorInfo(), ' ')
+            ));
         }
 
         $roles = [];
@@ -175,8 +175,8 @@ class PdoDatabase implements UserRepositoryInterface
         if (! $stmt->execute()) {
             throw new Exception\RuntimeException(sprintf(
                 "Error when running query from config sql_get_details: "
-                .implode($stmt->errorInfo(),' ')) 
-            );  
+                .implode($stmt->errorInfo(), ' ')
+            ));
         }
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }

--- a/src/UserRepository/PdoDatabase.php
+++ b/src/UserRepository/PdoDatabase.php
@@ -126,7 +126,10 @@ class PdoDatabase implements UserRepositoryInterface
         $stmt->bindParam(':identity', $identity);
 
         if (! $stmt->execute()) {
-            return [];
+            throw new Exception\RuntimeException(sprintf(
+                "Error when running query from config sql_get_roles: "
+                .implode($stmt->errorInfo(),' '))
+            );
         }
 
         $roles = [];
@@ -170,7 +173,10 @@ class PdoDatabase implements UserRepositoryInterface
         $stmt->bindParam(':identity', $identity);
 
         if (! $stmt->execute()) {
-            return [];
+            throw new Exception\RuntimeException(sprintf(
+                "Error when running query from config sql_get_details: "
+                .implode($stmt->errorInfo(),' ')) 
+            );  
         }
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }


### PR DESCRIPTION
Throw an exception when we find out that execute() did not work. Since execute() returns false when there is an error we can bubble this up to let the user know their auth roles or auth details query from the config was incorrect.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
     **If the user puts an incorrect sql query in their auth config it will role over this without telling them it was wrong.**
  - [x] Detail the original, incorrect behavior.
     **If an incorrect sql query is used in the auth config it will show every user has possibly no role or no details**
  - [x] Detail the new, expected behavior.
     **When an incorrect sql query is passed in the config and ran against the db a runtime exception will be thrown showing the details return from errorInfo() on the prepared statement.**
  - [x] Base your feature on the `master` branch, and submit against that branch.
